### PR TITLE
Mark .js files as Vue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js linguist-language=Vue


### PR DESCRIPTION
# Change
Mark `.js` files as `.vue` files for linguist.
# Justification
While these files are technically `.js` files, all of `main.js` is written in Vue so it should be marked as such. `constants.js` is purely  JavaScript, but is small enough so that the incorrect flagging won't matter.