### PR TITLE
Resolve null version error

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -98,19 +98,7 @@ function cbfunc(json) {     //the callback function
         generator.card.title = data._id;
         generator.card.link = generator.link;
         generator.card.slug = data.description;
-
-        let currentVer = data['dist-tags'].latest;
-        let currentVerInfo = null;
-
-        for (let version in data.versions) {
-            if (data.versions.hasOwnProperty(version)) {
-                if (data.versions[version].version === currentVer) {
-                    currentVerInfo = data.versions[version];
-                }
-            }
-        }
-
-        generator.card.details = currentVerInfo.version;
+        generator.card.details = data['dist-tags'].latest;
         generator.cardReady = true;
 
    } else {


### PR DESCRIPTION
### Overview
Removing the version search loop with a direct assignment seems to fix this error. 

### Details
`packageStem` values of  `'albatross'`, `'edward'`, and others resulted in an error before this fix as the loop condition would never flag as true, thus `currentVerInfo`  was never assigned and resulted in an error when this null variable was accessed at the end of this method.

Simplify removing the loop and setting `generator.card.details` to `currentVer` or `data['dist-tags'].latest` works as intended. Setting `generator.card.details` to `currentVer.version` or  `data['dist-tags'].latest.version` won't work as this property is undefined.

This fix corrects all instances of this error that I've seen but should undergo more testing to make sure this method is accurate and matches the package page.