### PR TITLE
Disable mobile scaling, fixes #8

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
     <meta name="description" content="Website poking fun at dull JavaScript library/framework naming conventions.">
     <meta name="keywords" content="noun.js, javascript-library, javascript-framework, npm, node.js, vue.js">
     <meta name="author" content="Michael Van Leeuwen, Radu Vasilescu">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
     <!-- Icons -->


### PR DESCRIPTION
Removed the meta viewport tag, essentially forcing the mobile browser to render a zoomed-out, "desktop" version of the site until we can actually get some responsive design up in here.